### PR TITLE
[JENKINS-35445] Custom HtmlUnit Dependency for JTH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,8 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+# Idea files
+*.iml
+.idea/
+

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.35</version>
+    <version>1.36</version>
   </parent>
 
   <!-- Version number [htmlunit-version]-[this artifact iteration for that version] -->

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.jenkins-ci</groupId>
+    <artifactId>jenkins</artifactId>
+    <version>1.35</version>
+  </parent>
+
+  <!-- Version number [htmlunit-version]-[this artifact iteration for that version] -->
+  <groupId>org.jenkins-ci.main</groupId>
+  <artifactId>jenkins-test-harness-htmlunit</artifactId>
+  <version>2.18-1-SNAPSHOT</version>
+
+  <name>HtmlUnit dependency for Jenkins Test Harness</name>
+  <description>Encapsulates HtmlUnit dependency, shading conflicting dependencies.</description>
+
+  <scm>
+    <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}.git</connection>
+    <developerConnection>scm:git:ssh://git@github.com/jenkinsci/${project.artifactId}.git</developerConnection>
+    <url>https://github.com/jenkinsci/${project.artifactId}</url>
+    <tag>HEAD</tag>
+  </scm>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <licenses>
+    <!-- Uses HtmlUnit license. -->
+    <license>
+      <name>Apache 2</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+    </license>
+  </licenses>
+
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>net.sourceforge.htmlunit</groupId>
+      <artifactId>htmlunit</artifactId>
+      <version>2.18</version>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-codec</groupId>
+          <artifactId>commons-codec</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>2.4.3</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <artifactSet>
+                <includes>
+                  <include>net.sourceforge.htmlunit:*</include>
+                  <include>org.apache.httpcomponents:*</include>
+                </includes>
+              </artifactSet>
+              <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+              <relocations>
+                <relocation>
+                  <pattern>org.apache.http</pattern>
+                  <shadedPattern>hidden.jth.org.apache.http</shadedPattern>
+                </relocation>
+              </relocations>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>


### PR DESCRIPTION
See [JENKINS-35445](https://issues.jenkins-ci.org/browse/JENKINS-35445)

The proposed solution is to create a custom `HtmlUnit` dependency that shades the problematic dependencies (the Apache HttpComponents).

I'd prefer not to go the shading way, but as described in the ticket in some plugins we can get to a catch-22 situation, and IMHO we should avoid having to change the dependencies in the `compile` scope because the ones in the `test`, as the consequences may be difficult to foresee, above all when they are some levels down the transitive resolution.

Because of that, the relocation is limited to the HttpComponents libraries, as they are the ones causing the greater conflicts (incompatible versions in `compile` and `test` scopes).

Downstream PRs will follow to show application to some plugins.

@reviewbybees 